### PR TITLE
Modify the publish action to only run when PS code changes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@
   push:
     paths:
       - UCM
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 ﻿on:
   push:
-    branches:
-      - master
-      - main
+    paths:
+      - UCM
 
 jobs:
   build:


### PR DESCRIPTION
As with the fix for #1 (which only involved a README.md change) it's not necessary to build a new version.

This change only executes the build GitHub action if the contents of the UCM folder changes.

Also allows the build to be run manully.